### PR TITLE
Solved error on profile. Sometimes getReservations executes before ge…

### DIFF
--- a/frontend/src/components/Profile.vue
+++ b/frontend/src/components/Profile.vue
@@ -356,6 +356,7 @@ export default {
           for (let i = 0; i < this.myFavorites.length; i++) {
             this.myFavorites[i].housing.url = 'favorite'
           }
+          this.getUserReservations()
         })
         .catch((error) => {
           this.myFavorites = null
@@ -455,7 +456,6 @@ export default {
     this.loadLocalStorage()
     this.getUserHouses()
     this.getUserFavorites()
-    this.getUserReservations()
     this.getUserReservedHouses()
     this.showLoader()
     setTimeout(() => {


### PR DESCRIPTION
…tFavorites and causes the getReservations method to crash, resulting in the list of reservations to not whos. This has been solved by calling gerReservations inside getFavorites.